### PR TITLE
Improvements to external link detection

### DIFF
--- a/TextformatterMarkExternalLinks.module
+++ b/TextformatterMarkExternalLinks.module
@@ -17,7 +17,7 @@ class TextformatterMarkExternalLinks extends Textformatter {
 	public static function getModuleInfo() {
 		return array(
 			'title' => 'Mark External Links', 
-			'version' => 102, 
+			'version' => 103, 
 			'summary' => "Adds a class='external' and a rel='nofollow' to every external link."
 		); 
 	}
@@ -28,19 +28,15 @@ class TextformatterMarkExternalLinks extends Textformatter {
 	
 	function mark_external($match) { 
 	    list($original, $tag) = $match;  
-
-	    $blog_url = 'http://'.$this->config->httpHost.$this->config->urls->root;
-	
-	    if(strpos($tag, "nofollow")) {
+	    if(preg_match('%\srel=(\'|")?[^\1]*nofollow(\s|\1|$)%i', $tag)) {
 	        return $original;
-	    } elseif(!strpos($tag, 'http')) {
-	    	 return $original;
-	    } elseif(strpos($tag, $blog_url)) {
-	    	 return $original;
-	    } else {
-	        return "<$tag rel='nofollow' class='external'>";
 	    }
+	    $host = preg_quote($this->config->httpHost, "%");
+	    $root = $this->config->urls->root ? preg_quote(rtrim($this->config->urls->root ,"/"), "%") : "";
+	    if(preg_match('%\shref=(\'|")?(?:[\.]+|(?:https?:)?//'.$host.$root.'|(?!//)'.$root.')(?:/|\1|\?|#|\s|$)%is', $tag)) {
+	        return $original;
+	    }
+	    return "<$tag rel='nofollow' class='external'>";
 	}
 
 }
-?>


### PR DESCRIPTION
Just bumped into this module today and thought I'd suggest some improvements. The main point here is to detect external links with regex, which should introduce a couple of benefits:
- String "nofollow" anywhere in the link or won't prevent it from being identified as an external link
- Internal links are identified correctly regardless of protocol (http, https, or non-specified)
- Most relative links are identified correctly

Switching to regex checks is of course going to be a bit slower, but on the other hand it should yield better results :)
